### PR TITLE
Add color temperature command

### DIFF
--- a/src/driver_zigbee.cpp
+++ b/src/driver_zigbee.cpp
@@ -137,6 +137,20 @@ bool ZigbeeDriver::ProcessConfig(const pb::driver::DriverConfig& config) {
                           .movetohueandsat_params()
                           .transition_time());
         command += buf;
+      } else if (zigbee_msg.zcl_cmd().colorcontrol_cmd().type() ==
+                  pb::comm::ZigBeeMsg::ZCLCmd::ColorControlCmd::
+                      MOVETOCOLORTEMP) {
+        char buf[128];
+        std::snprintf(buf, sizeof buf, "movetocolortemp 0x%04X 0x%04X",
+                      zigbee_msg.zcl_cmd()
+                          .colorcontrol_cmd()
+                          .movetocolortemp_params()
+                          .color_temperature(),
+                      zigbee_msg.zcl_cmd()
+                          .colorcontrol_cmd()
+                          .movetocolortemp_params()
+                          .transition_time());
+        command += buf;
       } else {
         command_error = true;
       }


### PR DESCRIPTION
Allows to set the color temperature (warm white <-> cold white) for non-color zigbee bulbs. 

Protocol buffers have to be extended before merging this addition (see: https://github.com/matrix-io/protocol-buffers/pull/76).